### PR TITLE
Add OPDS page streaming for undownloaded chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -437,7 +437,7 @@ object MangaController {
             },
             behaviorOf = { ctx, chapterId ->
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzDownload(chapterId) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
                         .thenApply { (inputStream, contentType, fileName) ->
                             ctx.header("Content-Type", contentType)
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -29,6 +29,10 @@ object OpdsAPI {
                 get(OpdsV1Controller.mangaFeed)
             }
 
+            path("manga/{mangaId}/chapter/{chapterId}/fetch") {
+                get(OpdsV1Controller.chapterMetadataFeed)
+            }
+
             path("source/{sourceId}") {
                 get(OpdsV1Controller.sourceFeed)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -278,6 +278,31 @@ object OpdsV1Controller {
             },
         )
 
+    var chapterMetadataFeed =
+        handler(
+            pathParam<Int>("mangaId"),
+            pathParam<Int>("chapterId"),
+            documentWith = {
+                withOperation {
+                    summary("OPDS Chapter Details Feed")
+                    description("OPDS feed for a specific undownloaded chapter of a manga")
+                }
+            },
+            behaviorOf = { ctx, mangaId, chapterId ->
+                ctx.future {
+                    future {
+                        Opds.getChapterMetadataFeed(mangaId, chapterId, BASE_URL)
+                    }.thenApply { xml ->
+                        ctx.contentType(OPDS_MIME).result(xml)
+                    }
+                }
+            },
+            withResults = {
+                httpCode(HttpStatus.OK)
+                httpCode(HttpStatus.NOT_FOUND)
+            },
+        )
+
     // Specific Source Feed
     val sourceFeed =
         handler(


### PR DESCRIPTION
### Changes
- Added OPDS-PSE support for undownloaded chapters.
- Modified GET chapter/{{chapterId}/download to create a CBZ file for folder downloads.
- Removed manga descriptions from chapter entries to reduce XML size for manga with very long descriptions. Each chapter entry now returns the manga title, chapter name, and the scanlator.

### Notes
- OPDS-PSE doesn't work without pageCount, and the redirected endpoint also fails even if we return a hardcode the count in the chapter entry. So, added a check in [ChapterForDownload](https://github.com/Suwayomi/Suwayomi-Server/blob/4f7962c98bb7fd0c04771e894a2aa72a2c155711/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt#L41-L40) to update the PageTableList & PageCount only when there is a mismatch.
-I tried making this call for all chapters in the paginated manga feed, but even with just 20 entries per page, it felt pretty slow. Plus, OPDS clients don’t really seem to support seamless chapter reading (KOReader definitely doesn’t). So instead, I added a separate “detail” page for each chapter when the page count is missing. This way, we can read undownloaded chapters, and if we revisit the chapter later, it won’t redirect us to the detail page again.

**_FYI: I use KOReader to read manga, so this entire modification is based on that._**


https://github.com/user-attachments/assets/458fb38f-510a-4d26-990c-9d0672eb6f9e

