### PR TITLE
Add autoCrop image for OPDS feed...

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -226,8 +226,6 @@ jobs:
       - name: Upload Preview Release
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
-          repository: "Suwayomi/Suwayomi-Server-preview"
           tag_name:  ${{ steps.GenTagName.outputs.value }}
           files: release/*
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -194,13 +194,10 @@ jobs:
           name: windows-x64
           path: release
 
-      - name: Checkout Preview branch
+      - name: Checkout current repository
         uses: actions/checkout@v4
         with:
-          repository: "Suwayomi/Suwayomi-Server-preview"
           ref: main
-          path: preview
-          token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
 
       - name: Generate Tag Name
         id: GenTagName

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -9,6 +9,7 @@ package suwayomi.tachidesk.manga
 
 import io.javalin.apibuilder.ApiBuilder.delete
 import io.javalin.apibuilder.ApiBuilder.get
+import io.javalin.apibuilder.ApiBuilder.head
 import io.javalin.apibuilder.ApiBuilder.patch
 import io.javalin.apibuilder.ApiBuilder.path
 import io.javalin.apibuilder.ApiBuilder.post
@@ -83,6 +84,7 @@ object MangaAPI {
         path("chapter") {
             post("batch", MangaController.anyChapterBatch)
             get("{chapterId}/download", MangaController.downloadChapter)
+            head("{chapterId}/download", MangaController.downloadChapter)
         }
 
         path("category") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -402,6 +402,7 @@ object MangaController {
             pathParam<Int>("chapterIndex"),
             pathParam<Int>("index"),
             queryParam<Boolean?>("updateProgress"),
+            queryParam<Boolean?>("cropImage"),
             documentWith = {
                 withOperation {
                     summary("Get a chapter page")
@@ -410,9 +411,9 @@ object MangaController {
                     )
                 }
             },
-            behaviorOf = { ctx, mangaId, chapterIndex, index, updateProgress ->
+            behaviorOf = { ctx, mangaId, chapterIndex, index, updateProgress, cropImage ->
                 ctx.future {
-                    future { Page.getPageImage(mangaId, chapterIndex, index, null) }
+                    future { Page.getPageImage(mangaId, chapterIndex, index, cropImage, null) }
                         .thenApply {
                             ctx.header("content-type", it.second)
                             val httpCacheSeconds = 1.days.inWholeSeconds

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -436,15 +436,17 @@ object MangaController {
     val downloadChapter =
         handler(
             pathParam<Int>("chapterId"),
+            queryParam<Boolean?>("markAsRead"),
             documentWith = {
                 withOperation {
                     summary("Download chapter as CBZ")
                     description("Get the CBZ file of the specified chapter")
                 }
             },
-            behaviorOf = { ctx, chapterId ->
+            behaviorOf = { ctx, chapterId, markAsRead ->
+                val shouldMarkAsRead = if (ctx.method() == HandlerType.HEAD) false else markAsRead
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId, shouldMarkAsRead) }
                         .thenApply { (inputStream, fileName, fileSize) ->
                             ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -7,6 +7,7 @@ package suwayomi.tachidesk.manga.controller
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import io.javalin.http.HandlerType
 import io.javalin.http.HttpStatus
 import kotlinx.serialization.json.Json
 import suwayomi.tachidesk.manga.impl.CategoryManga
@@ -448,7 +449,11 @@ object MangaController {
                             ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")
                             ctx.header("Content-Length", fileSize.toString())
-                            ctx.result(inputStream)
+                            if (ctx.method() == HandlerType.HEAD) {
+                                ctx.status(200)
+                            } else {
+                                ctx.result(inputStream)
+                            }
                         }
                 }
             },

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -52,7 +52,9 @@ object ChapterDownloadHelper {
         chapterId: Int,
     ): Pair<InputStream, Long> = provider(mangaId, chapterId).getAsArchiveStream()
 
-    fun getCbzForDownload(chapterId: Int): Triple<InputStream, String, Long> {
+    fun getCbzForDownload(chapterId: Int,
+                          markAsRead: Boolean?,
+                          ): Triple<InputStream, String, Long> {
         val (chapterData, mangaTitle) =
             transaction {
                 val row =
@@ -68,6 +70,17 @@ object ChapterDownloadHelper {
         val fileName = "$mangaTitle - [${chapterData.scanlator}] ${chapterData.name}.cbz"
 
         val cbzFile = provider(chapterData.mangaId, chapterData.id).getAsArchiveStream()
+
+        if (markAsRead == true) {
+            Chapter.modifyChapter(
+                chapterData.mangaId,
+                chapterData.index,
+                isRead = true,
+                isBookmarked = null,
+                markPrevRead = null,
+                lastPageRead = null,
+            )
+        }
 
         return Triple(cbzFile.first, fileName, cbzFile.second)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -52,9 +52,10 @@ object ChapterDownloadHelper {
         chapterId: Int,
     ): Pair<InputStream, Long> = provider(mangaId, chapterId).getAsArchiveStream()
 
-    fun getCbzForDownload(chapterId: Int,
-                          markAsRead: Boolean?,
-                          ): Triple<InputStream, String, Long> {
+    fun getCbzForDownload(
+        chapterId: Int,
+        markAsRead: Boolean?,
+    ): Triple<InputStream, String, Long> {
         val (chapterData, mangaTitle) =
             transaction {
                 val row =

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -18,6 +18,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import suwayomi.tachidesk.manga.impl.util.getChapterCachePath
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
+import suwayomi.tachidesk.manga.impl.util.storage.ImageAutoCrop
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse.getImageResponse
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
 import suwayomi.tachidesk.manga.model.table.ChapterTable
@@ -109,7 +110,7 @@ object Page {
             if (chapterEntry[ChapterTable.isDownloaded]) {
                 val image = ChapterDownloadHelper.getImage(mangaId, chapterId, index)
                 if (cropImage == true) {
-                    return ImageUtil.autoCropBorders(image.first) to image.second
+                    return ImageAutoCrop.autoCropBorders(image.first) to image.second
                 }
                 return image
             }
@@ -126,7 +127,7 @@ object Page {
             }
 
         if (cropImage == true) {
-            return ImageUtil.autoCropBorders(imageResponse.first) to imageResponse.second
+            return ImageAutoCrop.autoCropBorders(imageResponse.first) to imageResponse.second
         }
 
         return imageResponse

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -45,6 +45,7 @@ object Page {
         mangaId: Int,
         chapterIndex: Int,
         index: Int,
+        cropImage: Boolean? = false,
         progressFlow: ((StateFlow<Int>) -> Unit)? = null,
     ): Pair<InputStream, String> {
         val mangaEntry = transaction { MangaTable.selectAll().where { MangaTable.id eq mangaId }.first() }
@@ -106,7 +107,11 @@ object Page {
 
         try {
             if (chapterEntry[ChapterTable.isDownloaded]) {
-                return ChapterDownloadHelper.getImage(mangaId, chapterId, index)
+                val image = ChapterDownloadHelper.getImage(mangaId, chapterId, index)
+                if (cropImage == true) {
+                    return ImageUtil.autoCropBorders(image.first) to image.second
+                }
+                return image
             }
         } catch (_: Exception) {
             // ignore and fetch again
@@ -115,9 +120,16 @@ object Page {
         val cacheSaveDir = getChapterCachePath(mangaId, chapterId)
 
         // Note: don't care about invalidating cache because OS cache is not permanent
-        return getImageResponse(cacheSaveDir, fileName) {
-            source.getImage(tachiyomiPage)
+        val imageResponse =
+            getImageResponse(cacheSaveDir, fileName) {
+                source.getImage(tachiyomiPage)
+            }
+
+        if (cropImage == true) {
+            return ImageUtil.autoCropBorders(imageResponse.first) to imageResponse.second
         }
+
+        return imageResponse
     }
 
     /** converts 0 to "001" */

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageAutoCrop.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageAutoCrop.kt
@@ -1,0 +1,166 @@
+package suwayomi.tachidesk.manga.impl.util.storage
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+object ImageAutoCrop {
+    private const val FILLED_RATIO_LIMIT = 0.0025
+    private const val THRESHOLD = 0.5
+    private const val MARGIN = 4
+    private val BORDER_COLOR_CONFIG = BorderColorConfig(scanSteps = 10, pixelCount = 5)
+
+    fun autoCropBorders(inputStream: InputStream): InputStream {
+        val originalImage = ImageIO.read(inputStream) ?: throw IllegalArgumentException("Invalid image input")
+        val width = originalImage.width
+        val height = originalImage.height
+
+        val borderColorByDirection = detectBorderColors(originalImage, width, height)
+        val (left, top, right, bottom) = findBorderBoundaries(originalImage, width, height, borderColorByDirection)
+
+        if (left >= right || top >= bottom) return inputStream
+
+        val croppedImage =
+            originalImage.getSubimage(
+                maxOf(0, left - MARGIN),
+                maxOf(0, top - MARGIN),
+                minOf(width, right + MARGIN) - maxOf(0, left - MARGIN),
+                minOf(height, bottom + MARGIN) - maxOf(0, top - MARGIN),
+            )
+
+        val outputStream = ByteArrayOutputStream()
+        ImageIO.write(croppedImage, "png", outputStream)
+        return ByteArrayInputStream(outputStream.toByteArray())
+    }
+
+    private fun detectBorderColors(
+        image: BufferedImage,
+        width: Int,
+        height: Int,
+    ): Map<BorderDirection, Int> {
+        val stepY = height / BORDER_COLOR_CONFIG.scanSteps // Steps along height
+        val stepX = width / BORDER_COLOR_CONFIG.scanSteps // Steps along width
+
+        val samples = BorderDirection.entries.associateWith { mutableListOf<Int>() }.toMutableMap()
+
+        for (i in 0 until BORDER_COLOR_CONFIG.scanSteps) {
+            val y = i * stepY
+            val x = i * stepX
+
+            // Sample multiple pixels across the fixed coordinate for better accuracy
+            for (offset in 0 until BORDER_COLOR_CONFIG.pixelCount) {
+                samples[BorderDirection.LEFT]!!.add(image.getRGB(minOf(offset, width - 1), y))
+                samples[BorderDirection.RIGHT]!!.add(image.getRGB(maxOf(width - 1 - offset, 0), y))
+                samples[BorderDirection.TOP]!!.add(image.getRGB(x, minOf(offset, height - 1)))
+                samples[BorderDirection.BOTTOM]!!.add(image.getRGB(x, maxOf(height - 1 - offset, 0)))
+            }
+        }
+
+        return samples.mapValues { (_, values) ->
+            values
+                .groupingBy { it }
+                .eachCount()
+                .maxByOrNull { it.value }
+                ?.key ?: 0xFFFFFF
+        }
+    }
+
+    private fun findBorderBoundaries(
+        image: BufferedImage,
+        width: Int,
+        height: Int,
+        bgColorMap: Map<BorderDirection, Int>,
+    ): BorderBoundaries {
+        val top = findBorder(image, width, height, bgColor = bgColorMap[BorderDirection.TOP] ?: 0xFFFFFF, direction = BorderDirection.TOP)
+        val bottom =
+            findBorder(image, width, height, bgColor = bgColorMap[BorderDirection.BOTTOM] ?: 0xFFFFFF, direction = BorderDirection.BOTTOM)
+        val left = findBorder(image, width, height, top, bottom, bgColorMap[BorderDirection.LEFT] ?: 0xFFFFFF, BorderDirection.LEFT)
+        val right = findBorder(image, width, height, top, bottom, bgColorMap[BorderDirection.RIGHT] ?: 0xFFFFFF, BorderDirection.RIGHT)
+
+        return BorderBoundaries(left, top, right, bottom)
+    }
+
+    private fun findBorder(
+        image: BufferedImage,
+        width: Int,
+        height: Int,
+        top: Int = 0,
+        bottom: Int = height,
+        bgColor: Int,
+        direction: BorderDirection,
+    ): Int =
+        when (direction) {
+            BorderDirection.LEFT -> (0 until width).firstOrNull { hasSignificantContent(image, it, top, bottom, bgColor) } ?: 0
+            BorderDirection.RIGHT ->
+                (width - 1 downTo 0).firstOrNull { hasSignificantContent(image, it, top, bottom, bgColor) }?.plus(1)
+                    ?: width
+            BorderDirection.TOP ->
+                (0 until height).firstOrNull { hasSignificantContent(image, it, 0, width, bgColor, horizontal = true) }
+                    ?: 0
+            BorderDirection.BOTTOM ->
+                (height - 1 downTo 0).firstOrNull { hasSignificantContent(image, it, 0, width, bgColor, horizontal = true) }?.plus(1)
+                    ?: height
+        }
+
+    private fun hasSignificantContent(
+        image: BufferedImage,
+        pos: Int,
+        start: Int,
+        end: Int,
+        bgColor: Int,
+        horizontal: Boolean = false,
+    ): Boolean {
+        val filledLimit = ((end - start) * FILLED_RATIO_LIMIT).roundToInt()
+        var count = 0
+        for (i in start until end step 2) {
+            val pixel = if (horizontal) image.getRGB(i, pos) else image.getRGB(pos, i)
+            if (!isSimilar(pixel, bgColor)) count++
+            if (count > filledLimit) return true
+        }
+        return false
+    }
+
+    private fun isSimilar(
+        color1: Int,
+        color2: Int,
+    ): Boolean {
+        val diff =
+            abs((color1 and 0xFF) - (color2 and 0xFF)) +
+                abs(((color1 shr 8) and 0xFF) - ((color2 shr 8) and 0xFF)) +
+                abs(((color1 shr 16) and 0xFF) - ((color2 shr 16) and 0xFF))
+        return diff < (255 * THRESHOLD).toInt()
+    }
+
+    data class BorderBoundaries(
+        val left: Int,
+        val top: Int,
+        val right: Int,
+        val bottom: Int,
+    )
+
+    /**
+     * Configuration for border color detection.
+     *
+     * This will scan a total of `scanSteps * pixelCount` pixels per side.
+     * - `scanSteps`: Number of evenly spaced scan lines.
+     * - `pixelCount`: Number of adjacent pixels sampled per scan line.
+     *
+     * Example: If `scanSteps = 10` and `pixelCount = 5`, then `10 × 5 = 50` pixels
+     * will be considered per border side.
+     */
+    private data class BorderColorConfig(
+        val scanSteps: Int,
+        val pixelCount: Int,
+    )
+
+    enum class BorderDirection {
+        LEFT,
+        RIGHT,
+        TOP,
+        BOTTOM,
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageUtil.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageUtil.kt
@@ -14,14 +14,8 @@ import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil.ImageType.JPEG
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil.ImageType.JXL
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil.ImageType.PNG
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil.ImageType.WEBP
-import java.awt.image.BufferedImage
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URLConnection
-import javax.imageio.ImageIO
-import kotlin.math.max
-import kotlin.math.min
 
 // adopted from: eu.kanade.tachiyomi.util.system.ImageUtil
 object ImageUtil {
@@ -170,58 +164,5 @@ object ImageUtil {
         JXL("image/jxl", "jxl"),
         PNG("image/png", "png"),
         WEBP("image/webp", "webp"),
-    }
-
-    fun autoCropBorders(
-        inputStream: InputStream,
-        margin: Int = 2,
-    ): InputStream {
-        val originalImage = ImageIO.read(inputStream) ?: throw IllegalArgumentException("Invalid image input")
-
-        val width = originalImage.width
-        val height = originalImage.height
-
-        var top = height
-        var left = width
-        var bottom = 0
-        var right = 0
-
-        // Convert image to grayscale for better edge detection
-        val grayscaleImage = BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY)
-        val g = grayscaleImage.graphics
-        g.drawImage(originalImage, 0, 0, null)
-        g.dispose()
-
-        // Scan for the bounding box of non-white pixels
-        for (y in 0 until height) {
-            for (x in 0 until width) {
-                val pixel = grayscaleImage.getRGB(x, y) and 0xFF // Extract grayscale value
-                if (pixel < 245) { // Consider anything below 250 as non-white
-                    if (x < left) left = x
-                    if (x > right) right = x
-                    if (y < top) top = y
-                    if (y > bottom) bottom = y
-                }
-            }
-        }
-
-        // Expand the bounding box slightly to add a small margin
-        top = max(0, top - margin)
-        left = max(0, left - margin)
-        bottom = min(height - 1, bottom + margin)
-        right = min(width - 1, right + margin)
-
-        // Ensure valid crop dimensions
-        if (top >= bottom || left >= right) {
-            return inputStream // Return original input if no cropping is needed
-        }
-
-        // Crop the image
-        val croppedImage = originalImage.getSubimage(left, top, right - left + 1, bottom - top + 1)
-
-        // Convert back to InputStream
-        val outputStream = ByteArrayOutputStream()
-        ImageIO.write(croppedImage, "png", outputStream)
-        return ByteArrayInputStream(outputStream.toByteArray())
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -489,6 +489,7 @@ object Opds {
 
         val entryTitle =
             when {
+                isMetaDataEntry -> "⬇"
                 chapter.read -> "✅"
                 chapter.lastPageRead > 0 -> "⌛"
                 chapter.pageCount == 0 -> "❌"

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -37,7 +37,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 object Opds {
-    private const val ITEMS_PER_PAGE = 20
+    private const val ITEMS_PER_PAGE = 100
 
     fun getRootFeed(baseUrl: String): String {
         val builder =
@@ -515,7 +515,9 @@ object Opds {
                     add(
                         OpdsXmlModels.Link(
                             rel = "http://vaemendis.net/opds-pse/stream",
-                            href = "/api/v1/manga/${manga.id}/chapter/${chapter.index}/page/{pageNumber}?updateProgress=true",
+                            href =
+                                "/api/v1/manga/${manga.id}/chapter/${chapter.index}/" +
+                                    "page/{pageNumber}?cropImage=true&updateProgress=true",
                             type = "image/jpeg",
                             pseCount = chapter.pageCount,
                             pseLastRead = chapter.lastPageRead.takeIf { it != 0 },

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -507,7 +507,7 @@ object Opds {
                     add(
                         OpdsXmlModels.Link(
                             rel = "http://opds-spec.org/acquisition/open-access",
-                            href = "/api/v1/chapter/${chapter.id}/download",
+                            href = "/api/v1/chapter/${chapter.id}/download?markAsRead=true",
                             type = "application/vnd.comicbook+zip",
                         ),
                     )


### PR DESCRIPTION
Just adding this in case anyone else who uses the OPDS feed to read manga needs it.
"KOReader uses [ImageViewer](https://github.com/koreader/koreader/blob/3cf45b9dc878615bf951844d2504709249f3e37d/plugins/opds.koplugin/opdspse.lua#L95) to stream images. Now, while it works well, it doesn't have auto crop border like MuPDF does (for CBR files), and I don't want to go through the whole process of setting up a dev env for KOReader just to add this feature... This was way faster for my lazy bum and... well... that's all."