### PR TITLE
Feat: Adds OPDS Chapter Filtering/Ordering

### DIFF
--- a/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
+++ b/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
@@ -112,7 +112,8 @@ open class ConfigManager {
         value: Any,
     ) {
         mutex.withLock {
-            val configValue = ConfigValueFactory.fromAnyRef(value)
+            val actualValue = if (value is Enum<*>) value.name else value
+            val configValue = ConfigValueFactory.fromAnyRef(actualValue)
 
             updateUserConfigFile(path, configValue)
             internalConfig = internalConfig.withValue(path, configValue)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -186,6 +186,7 @@ class SettingsMutation {
         updateSetting(settings.opdsEnablePageReadProgress, serverConfig.opdsEnablePageReadProgress)
         updateSetting(settings.opdsMarkAsReadOnDownload, serverConfig.opdsMarkAsReadOnDownload)
         updateSetting(settings.opdsShowOnlyUnreadChapters, serverConfig.opdsShowOnlyUnreadChapters)
+        updateSetting(settings.opdsShowOnlyDownloadedChapters, serverConfig.opdsShowOnlyDownloadedChapters)
         updateSetting(settings.opdsChapterSortOrder, serverConfig.opdsChapterSortOrder)
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -94,6 +94,10 @@ class SettingsMutation {
 
         // local source
         validateFilePath(settings.localSourcePath, "localSourcePath")
+
+        // opds
+        validateValue(settings.opdsItemsPerPage, "opdsItemsPerPage") { it in 10..5000 }
+        validateValue(settings.opdsChapterSortOrder, "opdsChapterSortOrder") { it in listOf("ASC", "DESC") }
     }
 
     private fun <SettingType : Any> updateSetting(
@@ -177,6 +181,13 @@ class SettingsMutation {
         updateSetting(settings.flareSolverrSessionName, serverConfig.flareSolverrSessionName)
         updateSetting(settings.flareSolverrSessionTtl, serverConfig.flareSolverrSessionTtl)
         updateSetting(settings.flareSolverrAsResponseFallback, serverConfig.flareSolverrAsResponseFallback)
+
+        // opds
+        updateSetting(settings.opdsItemsPerPage, serverConfig.opdsItemsPerPage)
+        updateSetting(settings.opdsEnablePageReadProgress, serverConfig.opdsEnablePageReadProgress)
+        updateSetting(settings.opdsMarkAsReadOnDownload, serverConfig.opdsMarkAsReadOnDownload)
+        updateSetting(settings.opdsShowOnlyUnreadChapters, serverConfig.opdsShowOnlyUnreadChapters)
+        updateSetting(settings.opdsChapterSortOrder, serverConfig.opdsChapterSortOrder)
     }
 
     fun setSettings(input: SetSettingsInput): SetSettingsPayload {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -97,7 +97,6 @@ class SettingsMutation {
 
         // opds
         validateValue(settings.opdsItemsPerPage, "opdsItemsPerPage") { it in 10..5000 }
-        validateValue(settings.opdsChapterSortOrder, "opdsChapterSortOrder") { it in listOf("ASC", "DESC") }
     }
 
     private fun <SettingType : Any> updateSetting(

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -8,6 +8,7 @@
 package suwayomi.tachidesk.graphql.types
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
+import org.jetbrains.exposed.sql.SortOrder
 import suwayomi.tachidesk.graphql.server.primitives.Node
 import suwayomi.tachidesk.server.ServerConfig
 import suwayomi.tachidesk.server.serverConfig
@@ -98,7 +99,7 @@ interface Settings : Node {
     val opdsEnablePageReadProgress: Boolean?
     val opdsMarkAsReadOnDownload: Boolean?
     val opdsShowOnlyUnreadChapters: Boolean?
-    val opdsChapterSortOrder: String?
+    val opdsChapterSortOrder: SortOrder?
 }
 
 data class PartialSettingsType(
@@ -171,7 +172,7 @@ data class PartialSettingsType(
     override val opdsEnablePageReadProgress: Boolean?,
     override val opdsMarkAsReadOnDownload: Boolean?,
     override val opdsShowOnlyUnreadChapters: Boolean?,
-    override val opdsChapterSortOrder: String?,
+    override val opdsChapterSortOrder: SortOrder?,
 ) : Settings
 
 class SettingsType(
@@ -244,7 +245,7 @@ class SettingsType(
     override val opdsEnablePageReadProgress: Boolean,
     override val opdsMarkAsReadOnDownload: Boolean,
     override val opdsShowOnlyUnreadChapters: Boolean,
-    override val opdsChapterSortOrder: String,
+    override val opdsChapterSortOrder: SortOrder,
 ) : Settings {
     constructor(config: ServerConfig = serverConfig) : this(
         config.ip.value,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -92,6 +92,13 @@ interface Settings : Node {
     val flareSolverrSessionName: String?
     val flareSolverrSessionTtl: Int?
     val flareSolverrAsResponseFallback: Boolean?
+
+    // opds
+    val opdsItemsPerPage: Int?
+    val opdsEnablePageReadProgress: Boolean?
+    val opdsMarkAsReadOnDownload: Boolean?
+    val opdsShowOnlyUnreadChapters: Boolean?
+    val opdsChapterSortOrder: String?
 }
 
 data class PartialSettingsType(
@@ -159,6 +166,12 @@ data class PartialSettingsType(
     override val flareSolverrSessionName: String?,
     override val flareSolverrSessionTtl: Int?,
     override val flareSolverrAsResponseFallback: Boolean?,
+    // opds
+    override val opdsItemsPerPage: Int?,
+    override val opdsEnablePageReadProgress: Boolean?,
+    override val opdsMarkAsReadOnDownload: Boolean?,
+    override val opdsShowOnlyUnreadChapters: Boolean?,
+    override val opdsChapterSortOrder: String?,
 ) : Settings
 
 class SettingsType(
@@ -226,6 +239,12 @@ class SettingsType(
     override val flareSolverrSessionName: String,
     override val flareSolverrSessionTtl: Int,
     override val flareSolverrAsResponseFallback: Boolean,
+    // opds
+    override val opdsItemsPerPage: Int?,
+    override val opdsEnablePageReadProgress: Boolean?,
+    override val opdsMarkAsReadOnDownload: Boolean?,
+    override val opdsShowOnlyUnreadChapters: Boolean?,
+    override val opdsChapterSortOrder: String?,
 ) : Settings {
     constructor(config: ServerConfig = serverConfig) : this(
         config.ip.value,
@@ -287,5 +306,11 @@ class SettingsType(
         config.flareSolverrSessionName.value,
         config.flareSolverrSessionTtl.value,
         config.flareSolverrAsResponseFallback.value,
+        // opds
+        config.opdsItemsPerPage.value,
+        config.opdsEnablePageReadProgress.value,
+        config.opdsMarkAsReadOnDownload.value,
+        config.opdsShowOnlyUnreadChapters.value,
+        config.opdsChapterSortOrder.value,
     )
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -240,11 +240,11 @@ class SettingsType(
     override val flareSolverrSessionTtl: Int,
     override val flareSolverrAsResponseFallback: Boolean,
     // opds
-    override val opdsItemsPerPage: Int?,
-    override val opdsEnablePageReadProgress: Boolean?,
-    override val opdsMarkAsReadOnDownload: Boolean?,
-    override val opdsShowOnlyUnreadChapters: Boolean?,
-    override val opdsChapterSortOrder: String?,
+    override val opdsItemsPerPage: Int,
+    override val opdsEnablePageReadProgress: Boolean,
+    override val opdsMarkAsReadOnDownload: Boolean,
+    override val opdsShowOnlyUnreadChapters: Boolean,
+    override val opdsChapterSortOrder: String,
 ) : Settings {
     constructor(config: ServerConfig = serverConfig) : this(
         config.ip.value,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -99,6 +99,7 @@ interface Settings : Node {
     val opdsEnablePageReadProgress: Boolean?
     val opdsMarkAsReadOnDownload: Boolean?
     val opdsShowOnlyUnreadChapters: Boolean?
+    val opdsShowOnlyDownloadedChapters: Boolean?
     val opdsChapterSortOrder: SortOrder?
 }
 
@@ -172,6 +173,7 @@ data class PartialSettingsType(
     override val opdsEnablePageReadProgress: Boolean?,
     override val opdsMarkAsReadOnDownload: Boolean?,
     override val opdsShowOnlyUnreadChapters: Boolean?,
+    override val opdsShowOnlyDownloadedChapters: Boolean?,
     override val opdsChapterSortOrder: SortOrder?,
 ) : Settings
 
@@ -245,6 +247,7 @@ class SettingsType(
     override val opdsEnablePageReadProgress: Boolean,
     override val opdsMarkAsReadOnDownload: Boolean,
     override val opdsShowOnlyUnreadChapters: Boolean,
+    override val opdsShowOnlyDownloadedChapters: Boolean,
     override val opdsChapterSortOrder: SortOrder,
 ) : Settings {
     constructor(config: ServerConfig = serverConfig) : this(
@@ -312,6 +315,7 @@ class SettingsType(
         config.opdsEnablePageReadProgress.value,
         config.opdsMarkAsReadOnDownload.value,
         config.opdsShowOnlyUnreadChapters.value,
+        config.opdsShowOnlyDownloadedChapters.value,
         config.opdsChapterSortOrder.value,
     )
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -9,6 +9,7 @@ package suwayomi.tachidesk.manga
 
 import io.javalin.apibuilder.ApiBuilder.delete
 import io.javalin.apibuilder.ApiBuilder.get
+import io.javalin.apibuilder.ApiBuilder.head
 import io.javalin.apibuilder.ApiBuilder.patch
 import io.javalin.apibuilder.ApiBuilder.path
 import io.javalin.apibuilder.ApiBuilder.post
@@ -83,6 +84,7 @@ object MangaAPI {
         path("chapter") {
             post("batch", MangaController.anyChapterBatch)
             get("{chapterId}/download", MangaController.downloadChapter)
+            head("{chapterId}/download", MangaController.downloadChapter)
         }
 
         path("category") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -451,6 +451,7 @@ object MangaController {
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")
                             ctx.header("Content-Length", fileSize.toString())
                             if (ctx.method() == HandlerType.HEAD) {
+                                inputStream.close()
                                 ctx.status(200)
                             } else {
                                 ctx.result(inputStream)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -7,6 +7,7 @@ package suwayomi.tachidesk.manga.controller
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import io.javalin.http.HandlerType
 import io.javalin.http.HttpStatus
 import kotlinx.serialization.json.Json
 import suwayomi.tachidesk.manga.impl.CategoryManga
@@ -434,20 +435,26 @@ object MangaController {
     val downloadChapter =
         handler(
             pathParam<Int>("chapterId"),
+            queryParam<Boolean?>("markAsRead"),
             documentWith = {
                 withOperation {
                     summary("Download chapter as CBZ")
                     description("Get the CBZ file of the specified chapter")
                 }
             },
-            behaviorOf = { ctx, chapterId ->
+            behaviorOf = { ctx, chapterId, markAsRead ->
+                val shouldMarkAsRead = if (ctx.method() == HandlerType.HEAD) false else markAsRead
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId, shouldMarkAsRead) }
                         .thenApply { (inputStream, fileName, fileSize) ->
                             ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")
                             ctx.header("Content-Length", fileSize.toString())
-                            ctx.result(inputStream)
+                            if (ctx.method() == HandlerType.HEAD) {
+                                ctx.status(200)
+                            } else {
+                                ctx.result(inputStream)
+                            }
                         }
                 }
             },

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -57,7 +57,10 @@ object ChapterDownloadHelper {
         chapterId: Int,
     ): Pair<InputStream, Long> = provider(mangaId, chapterId).getAsArchiveStream()
 
-    fun getCbzForDownload(chapterId: Int): Triple<InputStream, String, Long> {
+    fun getCbzForDownload(
+        chapterId: Int,
+        markAsRead: Boolean?,
+    ): Triple<InputStream, String, Long> {
         val (chapterData, mangaTitle) =
             transaction {
                 val row =
@@ -73,6 +76,17 @@ object ChapterDownloadHelper {
         val fileName = "$mangaTitle - [${chapterData.scanlator}] ${chapterData.name}.cbz"
 
         val cbzFile = provider(chapterData.mangaId, chapterData.id).getAsArchiveStream()
+
+        if (markAsRead == true) {
+            Chapter.modifyChapter(
+                chapterData.mangaId,
+                chapterData.index,
+                isRead = true,
+                isBookmarked = null,
+                markPrevRead = null,
+                lastPageRead = null,
+            )
+        }
 
         return Triple(cbzFile.first, fileName, cbzFile.second)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -387,10 +387,7 @@ object Opds {
         baseUrl: String,
         pageNum: Int,
     ): String {
-        val sortOrder =
-            runCatching {
-                SortOrder.valueOf(serverConfig.opdsChapterSortOrder.value)
-            }.getOrElse { SortOrder.DESC }
+        val sortOrder = serverConfig.opdsChapterSortOrder.value
 
         val (manga, chapters, totalCount) =
             transaction {

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -387,9 +387,10 @@ object Opds {
         baseUrl: String,
         pageNum: Int,
     ): String {
-        val sortOrder = runCatching {
-            SortOrder.valueOf(serverConfig.opdsChapterSortOrder.value)
-        }.getOrElse { SortOrder.DESC }
+        val sortOrder =
+            runCatching {
+                SortOrder.valueOf(serverConfig.opdsChapterSortOrder.value)
+            }.getOrElse { SortOrder.DESC }
 
         val (manga, chapters, totalCount) =
             transaction {

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -403,6 +403,10 @@ object Opds {
                         if (serverConfig.opdsShowOnlyUnreadChapters.value) {
                             add(ChapterTable.isRead eq false)
                         }
+
+                        if (serverConfig.opdsShowOnlyDownloadedChapters.value) {
+                            add(ChapterTable.isDownloaded eq true)
+                        }
                         add(ChapterTable.manga eq mangaId)
                     }.reduce { acc, op -> acc and op }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ConfigAdapters.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ConfigAdapters.kt
@@ -1,5 +1,7 @@
 package suwayomi.tachidesk.server
 
+import org.jetbrains.exposed.sql.SortOrder
+
 interface ConfigAdapter<T> {
     fun toType(configValue: String): T
 }
@@ -18,4 +20,8 @@ object BooleanConfigAdapter : ConfigAdapter<Boolean> {
 
 object DoubleConfigAdapter : ConfigAdapter<Double> {
     override fun toType(configValue: String): Double = configValue.toDouble()
+}
+
+object SortOrderConfigAdapter : ConfigAdapter<SortOrder> {
+    override fun toType(configValue: String): SortOrder = SortOrder.valueOf(configValue)
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
+import org.jetbrains.exposed.sql.SortOrder
 import xyz.nulldev.ts.config.GlobalConfigManager
 import xyz.nulldev.ts.config.SystemPropertyOverridableConfigModule
 import kotlin.reflect.KProperty
@@ -160,7 +161,7 @@ class ServerConfig(
     val opdsEnablePageReadProgress: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val opdsMarkAsReadOnDownload: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val opdsShowOnlyUnreadChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
-    val opdsChapterSortOrder: MutableStateFlow<String> by OverrideConfigValue(StringConfigAdapter)
+    val opdsChapterSortOrder: MutableStateFlow<SortOrder> by OverrideConfigValue(SortOrderConfigAdapter)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun <T> subscribeTo(

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -161,6 +161,7 @@ class ServerConfig(
     val opdsEnablePageReadProgress: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val opdsMarkAsReadOnDownload: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val opdsShowOnlyUnreadChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
+    val opdsShowOnlyDownloadedChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val opdsChapterSortOrder: MutableStateFlow<SortOrder> by OverrideConfigValue(SortOrderConfigAdapter)
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -155,6 +155,13 @@ class ServerConfig(
     val flareSolverrSessionTtl: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
     val flareSolverrAsResponseFallback: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
 
+    // opds settings
+    val opdsItemsPerPage: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
+    val opdsEnablePageReadProgress: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
+    val opdsMarkAsReadOnDownload: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
+    val opdsShowOnlyUnreadChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
+    val opdsChapterSortOrder: MutableStateFlow<String> by OverrideConfigValue(StringConfigAdapter)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     fun <T> subscribeTo(
         flow: Flow<T>,

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -76,4 +76,5 @@ server.opdsItemsPerPage = 50 # Range (10 - 5000)
 server.opdsEnablePageReadProgress = true
 server.opdsMarkAsReadOnDownload = false
 server.opdsShowOnlyUnreadChapters = false
+server.opdsShowOnlyDownloadedChapters = false
 server.opdsChapterSortOrder = "DESC" # "ASC", "DESC"

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -70,3 +70,10 @@ server.flareSolverrTimeout = 60 # time in seconds
 server.flareSolverrSessionName = "suwayomi"
 server.flareSolverrSessionTtl = 15 # time in minutes
 server.flareSolverrAsResponseFallback = false
+
+# OPDS
+server.opdsItemsPerPage = 50 # Range (1 - 5000)
+server.opdsEnablePageReadProgress = true
+server.opdsMarkAsReadOnDownload = false
+server.opdsShowOnlyUnreadChapters = false
+server.opdsChapterSortOrder = "DESC" # "ASC", "DESC"

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -72,7 +72,7 @@ server.flareSolverrSessionTtl = 15 # time in minutes
 server.flareSolverrAsResponseFallback = false
 
 # OPDS
-server.opdsItemsPerPage = 50 # Range (1 - 5000)
+server.opdsItemsPerPage = 50 # Range (10 - 5000)
 server.opdsEnablePageReadProgress = true
 server.opdsMarkAsReadOnDownload = false
 server.opdsShowOnlyUnreadChapters = false

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -67,3 +67,10 @@ server.flareSolverrTimeout = 60 # time in seconds
 server.flareSolverrSessionName = "suwayomi"
 server.flareSolverrSessionTtl = 15 # time in minutes
 server.flareSolverrAsResponseFallback = false
+
+# OPDS
+server.opdsItemsPerPage = 50 # Range (1 - 5000)
+server.opdsEnablePageReadProgress = true
+server.opdsMarkAsReadOnDownload = false
+server.opdsShowOnlyUnreadChapters = false
+server.opdsChapterSortOrder = "DESC" # "ASC", "DESC"

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -73,4 +73,5 @@ server.opdsItemsPerPage = 50 # Range (10 - 5000)
 server.opdsEnablePageReadProgress = true
 server.opdsMarkAsReadOnDownload = false
 server.opdsShowOnlyUnreadChapters = false
+server.opdsShowOnlyDownloadedChapters = false
 server.opdsChapterSortOrder = "DESC" # "ASC", "DESC"

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -69,7 +69,7 @@ server.flareSolverrSessionTtl = 15 # time in minutes
 server.flareSolverrAsResponseFallback = false
 
 # OPDS
-server.opdsItemsPerPage = 50 # Range (1 - 5000)
+server.opdsItemsPerPage = 50 # Range (10 - 5000)
 server.opdsEnablePageReadProgress = true
 server.opdsMarkAsReadOnDownload = false
 server.opdsShowOnlyUnreadChapters = false


### PR DESCRIPTION
### OPDS
- Moved existing hardcoded OPDS settings to `server.conf`.
- Added `opdsMarkAsReadOnDownload`. Previously, I didn’t think it made much sense since we were hardcoding it, but now that we're using server.conf, I think it’s best to leave it up to the user
- Added a HEAD request for CBZ downloads. Some OPDS clients (mainly KOReader :3) use HEAD requests to pre-fetch the filename before downloading. _Clients usually fall back to a default <Title> + <Author>.cbz format if the HEAD request fails..._
- Added "⬇" in the ChapterEntry title for ChapterMetadataFeed to better differentiate it from the regular chapter feed.
Previously, both had the same title, which was confusing—especially for manga with only one chapter—making it feel like navigating through two identical feeds to reach the actual chapter. ~ Ref to end

```conf
# OPDS
server.opdsItemsPerPage = 50 # Range (1 - 5000)
server.opdsEnablePageReadProgress = true
server.opdsMarkAsReadOnDownload = false
server.opdsShowOnlyUnreadChapters = false
server.opdsChapterSortOrder = "DESC" # "ASC", "DESC"
```

If all goes well, hoping to add those in default web-ui as well..
<details>
<summary>Default Web-UI Setting tab with these setttings</summary>

![image](https://github.com/user-attachments/assets/9011f8d0-eacb-44dc-b14f-d622ebbbd07f)

</details>

<details>
<summary>"⬇" in the ChapterEntry title for ChapterMetadataFeed</summary>

https://github.com/user-attachments/assets/884064e0-e3e8-420f-92dc-a50dade2db2e
</details>



